### PR TITLE
Deserialization fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.binance.api</groupId>
   <artifactId>binance-api-client</artifactId>
-  <version>1.0.2-SNAPSHOT+TUNED</version>
+  <version>1.0.3-SNAPSHOT+TUNED</version>
   <licenses>
     <license>
       <name>The MIT License</name>

--- a/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
+++ b/src/main/java/com/binance/api/client/domain/general/RateLimitType.java
@@ -8,5 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public enum RateLimitType {
   REQUEST_WEIGHT,
-  ORDERS
+  ORDERS,
+  RAW_REQUESTS
 }


### PR DESCRIPTION
Resolve the below issue that occurred during the Binance order rules fetching. A missing enumerator caused a deserialization error in the API responses.

This issue was fixed in the forked repository: https://github.com/binance-exchange/binance-java-api/pull/384

ERROR --- [main] t.s.ExchangeOrderRulesFetcherService: Failed to fetch order rules
com.binance.api.client.exception.BinanceApiException: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.binance.api.client.domain.general.RateLimitType` from String "RAW_REQUESTS": not one of the values accepted for Enum class: [REQUEST_WEIGHT, ORDERS]
 at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 311] (through reference chain: com.binance.api.client.domain.general.ExchangeInfo["rateLimits"]->java.util.ArrayList[3]-